### PR TITLE
Fix entities 'Translation' operations

### DIFF
--- a/src/camera/systems.rs
+++ b/src/camera/systems.rs
@@ -13,6 +13,8 @@ pub fn follow_target(
     let mut camera = camera_query.single_mut();
 
     if let Ok(target) = target_query.get_single() {
-        camera.translation = target.translation.clone();
+        let mut temp_translation = target.translation.clone();
+        temp_translation.z = 0.0; // Since there is only 2 dimensions - Z is redundant
+        camera.translation = temp_translation;
     }
 }

--- a/src/entities/asteroid/events.rs
+++ b/src/entities/asteroid/events.rs
@@ -1,8 +1,7 @@
-
-use bevy::prelude::Vec3;
+use bevy::prelude::Vec2;
 
 pub struct AsteroidProperties {
-    pub position: Vec3,
+    pub position: Vec2,
     pub radius: f32,
     pub mass: f32,
 }

--- a/src/entities/asteroid/systems.rs
+++ b/src/entities/asteroid/systems.rs
@@ -1,55 +1,42 @@
-
 use bevy::{
     prelude::{
-        Commands,
-        Transform,
-        EventReader,
-        Vec3,
-        Vec2,
-        EventWriter,
-        Name,
+        info, BuildChildren, Commands, Entity, EventReader, EventWriter, Name, Query, Transform,
+        Vec2, Vec3, With,
     },
     transform::TransformBundle,
 };
 use bevy_rapier2d::prelude::*;
 use rand::Rng;
 
-use super::{
-    events::AsteroidProperties,
-    events::SpawnAsteroidEvent,
-    components::Asteroid,
-};
+use crate::game_play::level::components::Level;
 
-pub fn setup(
-    mut event_writer: EventWriter<SpawnAsteroidEvent>,
-) {
+use super::{components::Asteroid, events::AsteroidProperties, events::SpawnAsteroidEvent};
 
+pub fn setup(mut event_writer: EventWriter<SpawnAsteroidEvent>) {
     // TODO: Remove asteroid test spawn
     // Test spawn start
-    let properties: AsteroidProperties =
-    AsteroidProperties {
-        position: Vec3::new(
-            rand::thread_rng().gen_range(-100.0 .. 100.0),
-            rand::thread_rng().gen_range(-100.0 .. 100.0),
-            rand::thread_rng().gen_range(-100.0 .. 100.0)),
-        radius: rand::thread_rng().gen_range(10.0 .. 100.0),
-        mass: rand::thread_rng().gen_range(1.0 .. 100.0),
+    let properties: AsteroidProperties = AsteroidProperties {
+        position: Vec2::new(
+            rand::thread_rng().gen_range(-100.0..100.0),
+            rand::thread_rng().gen_range(-100.0..100.0),
+        ),
+        radius: rand::thread_rng().gen_range(10.0..100.0),
+        mass: rand::thread_rng().gen_range(1.0..100.0),
     };
-    event_writer.send(SpawnAsteroidEvent{properties});
+    event_writer.send(SpawnAsteroidEvent { properties });
     // Test spawn end
-
 }
 
 pub fn spawn_asteroid(
     mut commands: Commands,
     mut event_reader: EventReader<SpawnAsteroidEvent>,
+    level_query: Query<Entity, With<Level>>,
 ) {
-
     if event_reader.is_empty() {
         return;
     }
 
-    let mut position: Vec3 = Vec3::new(0.0, 0.0, 0.0);
+    let mut position: Vec2 = Vec2::new(0.0, 0.0);
     let mut radius: f32 = 10.0;
     let mut mass: f32 = 10.0;
 
@@ -58,27 +45,33 @@ pub fn spawn_asteroid(
         radius = event.properties.radius;
         mass = event.properties.mass;
     }
+    let level = level_query.get_single();
 
-    commands
-        .spawn((
-            Asteroid,
-            RigidBody::Dynamic,
-            Name::new(format!("Asteroid")),
-        ))
+    let asteroid = commands
+        .spawn((Asteroid, RigidBody::Dynamic, Name::new(format!("Asteroid"))))
         .insert(Collider::ball(radius))
         .insert(Restitution::coefficient(0.0))
-        .insert(TransformBundle::from(Transform::from_translation(position)))
+        .insert(TransformBundle::from(Transform::from_translation(
+            Vec3::new(position.x, position.y, 0.0),
+        )))
         .insert(GravityScale(0.0))
         .insert(ColliderMassProperties::Mass(mass))
-        .insert(Velocity{
-            linvel:
-                Vec2::new(
-                    rand::thread_rng().gen_range(0.0 .. 10.0),
-                    rand::thread_rng().gen_range(0.0 .. 10.0)
-                ),
-            angvel: rand::thread_rng().gen_range(0.0 .. 1.0)
+        .insert(Velocity {
+            linvel: Vec2::new(
+                rand::thread_rng().gen_range(0.0..10.0),
+                rand::thread_rng().gen_range(0.0..10.0),
+            ),
+            angvel: rand::thread_rng().gen_range(0.0..1.0),
         })
         .insert(Sleeping::disabled())
-        ;
+        .id();
 
+    match level {
+        Ok(entity) => {
+            commands.entity(entity).add_child(asteroid);
+        }
+        Err(_) => {
+            info!("Level not found");
+        }
+    };
 }

--- a/src/entities/asteroid/systems.rs
+++ b/src/entities/asteroid/systems.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::{
         info, BuildChildren, Commands, Entity, EventReader, EventWriter, Name, Query, Transform,
-        Vec2, Vec3, With,
+        Vec2, With,
     },
     transform::TransformBundle,
 };
@@ -36,7 +36,7 @@ pub fn spawn_asteroid(
         return;
     }
 
-    let mut position: Vec2 = Vec2::new(0.0, 0.0);
+    let mut position: Vec2 = Vec2::ZERO;
     let mut radius: f32 = 10.0;
     let mut mass: f32 = 10.0;
 
@@ -52,7 +52,8 @@ pub fn spawn_asteroid(
         .insert(Collider::ball(radius))
         .insert(Restitution::coefficient(0.0))
         .insert(TransformBundle::from(Transform::from_translation(
-            Vec3::new(position.x, position.y, 0.0),
+            // 'position' is a Vec2, but it takes a Vec3 to spawn, so an absent Z-axis value should be added
+            position.extend(0.0),
         )))
         .insert(GravityScale(0.0))
         .insert(ColliderMassProperties::Mass(mass))

--- a/src/entities/player/events.rs
+++ b/src/entities/player/events.rs
@@ -1,7 +1,7 @@
-use bevy::prelude::Vec3;
+use bevy::prelude::Vec2;
 
 pub struct PlayerProperties {
-    pub position: Vec3,
+    pub position: Vec2,
 }
 
 pub struct SpawnPlayerEvent {

--- a/src/entities/player/systems.rs
+++ b/src/entities/player/systems.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::{
         info, BuildChildren, Commands, Entity, EventReader, EventWriter, Name, Query, Transform,
-        Vec2, Vec3, With,
+        Vec2, With,
     },
     transform::TransformBundle,
 };
@@ -39,7 +39,7 @@ pub fn spawn_player(
         return;
     }
 
-    let mut position: Vec2 = Vec2::new(0.0, 0.0);
+    let mut position: Vec2 = Vec2::ZERO;
 
     for event in event_reader.iter() {
         position = event.properties.position;
@@ -56,12 +56,13 @@ pub fn spawn_player(
         .insert(Collider::cuboid(10.0, 25.0))
         .insert(Restitution::coefficient(0.0))
         .insert(TransformBundle::from(Transform::from_translation(
-            Vec3::new(position.x, position.y, 0.0),
+            // 'position' is a Vec2, but it takes a Vec3 to spawn, so an absent Z-axis value should be added
+            position.extend(0.0),
         )))
         .insert(GravityScale(0.0))
         .insert(ColliderMassProperties::Mass(10.0))
         .insert(Velocity {
-            linvel: Vec2::new(0.0, 0.0),
+            linvel: Vec2::ZERO,
             angvel: 0.0,
         })
         .insert(Sleeping::disabled())

--- a/src/entities/player/systems.rs
+++ b/src/entities/player/systems.rs
@@ -20,8 +20,7 @@ pub fn setup(mut event_writer: EventWriter<SpawnPlayerEvent>) {
     // TODO: Remove player test spawn
     // Test spawn start
     let properties: PlayerProperties = PlayerProperties {
-        position: Vec3::new(
-            rand::thread_rng().gen_range(-100.0..100.0),
+        position: Vec2::new(
             rand::thread_rng().gen_range(-100.0..100.0),
             rand::thread_rng().gen_range(-100.0..100.0),
         ),
@@ -40,7 +39,7 @@ pub fn spawn_player(
         return;
     }
 
-    let mut position: Vec3 = Vec3::new(0.0, 0.0, 0.0);
+    let mut position: Vec2 = Vec2::new(0.0, 0.0);
 
     for event in event_reader.iter() {
         position = event.properties.position;
@@ -56,7 +55,9 @@ pub fn spawn_player(
         ))
         .insert(Collider::cuboid(10.0, 25.0))
         .insert(Restitution::coefficient(0.0))
-        .insert(TransformBundle::from(Transform::from_translation(position)))
+        .insert(TransformBundle::from(Transform::from_translation(
+            Vec3::new(position.x, position.y, 0.0),
+        )))
         .insert(GravityScale(0.0))
         .insert(ColliderMassProperties::Mass(10.0))
         .insert(Velocity {


### PR DESCRIPTION
1) Change player and asteroid entities 'position' from Vec3 to Vec2;
2) Fix camera following its target;
3) Set asteroid entity to spawn as a level child.